### PR TITLE
Implement quiz generation page

### DIFF
--- a/frontend/src/QuizPage.js
+++ b/frontend/src/QuizPage.js
@@ -1,16 +1,103 @@
-import React from "react";
-import { Box, Typography, Paper } from "@mui/material";
+import React, { useState } from "react";
+import {
+  Box,
+  Typography,
+  Paper,
+  TextField,
+  Button,
+} from "@mui/material";
+import LoadingSpinner from "./Spinner";
+import { QAHeader } from "./QAHeader";
+import { modelList } from "./RAGModels";
 
 const QuizPage = () => {
+  const [certification, setCertification] = useState(
+    "AWS Certified Cloud Practitioner"
+  );
+  const [quizText, setQuizText] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [selectedModel, setSelectedModel] = useState(undefined);
+  const [loading, setLoading] = useState(false);
+
+  const generateQuiz = async () => {
+    if (!baseUrl) {
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(baseUrl + "docs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          question:
+            "Generate a 10 question multiple choice quiz for the " +
+            certification +
+            ". Provide the correct answer after each question.",
+          modelId: selectedModel?.modelId,
+        }),
+      });
+      const data = await res.json();
+      setQuizText(data.response);
+    } catch (err) {
+      console.log("Quiz error", err);
+      setQuizText(
+        "Error generating quiz. Please check your browser console and backend logs."
+      );
+    }
+    setLoading(false);
+  };
+
   return (
-    <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "100vh", backgroundColor: "#f0f0f0", padding: "30px" }}>
-      <Paper sx={{ padding: 8, maxWidth: 600, textAlign: "center" }}>
-        <Typography variant="h5" gutterBottom>
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: "100vh",
+        backgroundColor: "#f0f0f0",
+        padding: "30px",
+      }}
+    >
+      <Paper sx={{ padding: 8, maxWidth: 600 }}>
+        <Typography variant="h5" sx={{ textAlign: "center" }} gutterBottom>
           Quiz Page
         </Typography>
-        <Typography variant="body1">
-          Quiz functionality coming soon.
+        <QAHeader
+          setBaseUrl={setBaseUrl}
+          baseUrl={baseUrl}
+          modelList={modelList}
+          setSelectedModel={setSelectedModel}
+          selectedModel={selectedModel}
+        />
+        <Typography variant="overline" sx={{ paddingTop: "20px" }}>
+          Certification
         </Typography>
+        <TextField
+          fullWidth
+          variant="standard"
+          value={certification}
+          onChange={(e) => setCertification(e.target.value)}
+        />
+        <Box sx={{ paddingTop: "20px", textAlign: "center" }}>
+          <Button
+            variant="contained"
+            onClick={generateQuiz}
+            disabled={loading || !baseUrl}
+          >
+            Generate Quiz
+          </Button>
+        </Box>
+        <Box sx={{ paddingTop: "20px" }}>
+          {loading ? (
+            <Box sx={{ display: "flex", justifyContent: "center" }}>
+              <LoadingSpinner />
+            </Box>
+          ) : (
+            <Typography component="pre" sx={{ whiteSpace: "pre-wrap" }}>
+              {quizText}
+            </Typography>
+          )}
+        </Box>
       </Paper>
     </Box>
   );


### PR DESCRIPTION
## Summary
- add new quiz page that requests a quiz from the backend
- integrate base URL and model selection

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420d3c29148331b3bb1e798c120650