### PR TITLE
Improve UI styling

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -13,6 +13,12 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/frontend/src/Chat.js
+++ b/frontend/src/Chat.js
@@ -23,7 +23,7 @@ const Chat = (props) => {
     <Box
       ref={boxRef}
       sx={{
-        backgroundColor: "#f0f0f0",
+        backgroundColor: "#252F3E",
         paddingBottom: "20px",
         overflowY: "auto",
         maxHeight: "650px",

--- a/frontend/src/ChatApp.js
+++ b/frontend/src/ChatApp.js
@@ -143,7 +143,7 @@ const ChatApp = (props) => {
         alignItems: "center",
         minHeight: "100vh",
         padding: "30px",
-        backgroundColor: "#f0f0f0",
+        backgroundColor: "#252F3E",
       }}
     >
       <Paper
@@ -188,6 +188,7 @@ const ChatApp = (props) => {
               disabled={history.length === 0}
               startIcon={<DeleteIcon />}
               onClick={onClearHistory}
+              color="secondary"
             >
               Clear History
             </Button>
@@ -223,7 +224,7 @@ const ChatApp = (props) => {
           <IconButton
             disabled={spinner || !baseUrl}
             onClick={handleSendQuestion}
-            color="primary"
+            color="secondary"
           >
             <SendIcon />
           </IconButton>

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -3,7 +3,16 @@ import { Box, Paper, Typography, Button } from "@mui/material";
 
 const LandingPage = ({ onSelect }) => {
   return (
-    <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "100vh", backgroundColor: "#f0f0f0", padding: "30px" }}>
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: "100vh",
+        backgroundColor: "#252F3E",
+        padding: "30px",
+      }}
+    >
       <Paper sx={{ padding: 8, maxWidth: 600, textAlign: "center" }}>
         <Typography variant="h5" gutterBottom>
           Welcome to AWS Beacon
@@ -12,8 +21,8 @@ const LandingPage = ({ onSelect }) => {
           What would you like to do?
         </Typography>
         <Box sx={{ display: "flex", justifyContent: "center", gap: 2, paddingTop: 2 }}>
-          <Button variant="contained" onClick={() => onSelect("chat")}>Chat</Button>
-          <Button variant="contained" onClick={() => onSelect("quiz")}>Quiz</Button>
+          <Button variant="contained" color="secondary" onClick={() => onSelect("chat")}>Chat</Button>
+          <Button variant="contained" color="secondary" onClick={() => onSelect("quiz")}>Quiz</Button>
         </Box>
       </Paper>
     </Box>

--- a/frontend/src/QuizPage.js
+++ b/frontend/src/QuizPage.js
@@ -54,7 +54,7 @@ const QuizPage = () => {
         justifyContent: "center",
         alignItems: "center",
         minHeight: "100vh",
-        backgroundColor: "#f0f0f0",
+        backgroundColor: "#252F3E",
         padding: "30px",
       }}
     >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,10 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #252F3E;
+  color: #FFFFFF;
 }
 
 code {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,11 +3,47 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ThemeProvider, CssBaseline, createTheme } from '@mui/material';
+
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
+    background: {
+      default: '#252F3E',
+      paper: '#35445D',
+    },
+    text: {
+      primary: '#FFFFFF',
+      secondary: '#EAEDED',
+    },
+    primary: { main: '#0073BB' },
+    secondary: { main: '#FF9900' },
+  },
+  typography: {
+    fontFamily: '"Open Sans", "Helvetica Neue", Arial, sans-serif',
+    button: {
+      fontWeight: 'bold',
+      textTransform: 'none',
+    },
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+        },
+      },
+    },
+  },
+});
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- apply an AWS style MUI theme and fonts
- update landing page and chat UI colors
- darken background with AWS navy tone

## Testing
- `npm test --silent --yes` in `frontend` *(fails: react-scripts not found)*
- `npm test --silent` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684210254bec8331bc9deb1332d44b79