### PR TITLE
Update branding and add landing enhancements

### DIFF
--- a/frontend/public/aws-logo.svg
+++ b/frontend/public/aws-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 120">
+  <text x="0" y="80" font-family="Arial, Helvetica, sans-serif" font-size="60" fill="#232F3E" font-weight="bold">aws</text>
+  <path d="M20 90c30 15 60 25 100 25s70-10 100-25" fill="none" stroke="#FF9900" stroke-width="6"/>
+  <polyline points="180,95 205,95 195,80" fill="none" stroke="#FF9900" stroke-width="6"/>
+</svg>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -28,7 +28,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>AWS Q&A Sample built using Knowledge Bases for Amazon Bedrock</title>
+    <title>AWS Beacon Sample built using Knowledge Bases for Amazon Bedrock</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/ChatApp.js
+++ b/frontend/src/ChatApp.js
@@ -143,17 +143,19 @@ const ChatApp = (props) => {
         alignItems: "center",
         minHeight: "100vh",
         padding: "30px",
-        backgroundColor: "#252F3E",
+        background: "linear-gradient(135deg, #252F3E 0%, #1A202C 100%)",
       }}
     >
       <Paper
+        className="fade-in"
         sx={{
           padding: 8,
           maxWidth: 600,
+          boxShadow: 3,
         }}
       >
         <Typography variant="h5" sx={{ textAlign: "center" }}>
-          AWS Q&A
+          AWS Beacon
         </Typography>
         <br></br>
         <br></br>

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { Box, Paper, Typography, Button } from "@mui/material";
 
+const awsLogo = process.env.PUBLIC_URL + "/aws-logo.svg";
+
 const LandingPage = ({ onSelect }) => {
   return (
     <Box
@@ -9,11 +11,12 @@ const LandingPage = ({ onSelect }) => {
         justifyContent: "center",
         alignItems: "center",
         minHeight: "100vh",
-        backgroundColor: "#252F3E",
+        background: "linear-gradient(135deg, #252F3E 0%, #1A202C 100%)",
         padding: "30px",
       }}
     >
-      <Paper sx={{ padding: 8, maxWidth: 600, textAlign: "center" }}>
+      <Paper className="fade-in" sx={{ padding: 8, maxWidth: 600, textAlign: "center", boxShadow: 3 }}>
+        <img src={awsLogo} alt="AWS Logo" style={{ width: "120px", marginBottom: "20px" }} />
         <Typography variant="h5" gutterBottom>
           Welcome to AWS Beacon
         </Typography>
@@ -24,6 +27,9 @@ const LandingPage = ({ onSelect }) => {
           <Button variant="contained" color="secondary" onClick={() => onSelect("chat")}>Chat</Button>
           <Button variant="contained" color="secondary" onClick={() => onSelect("quiz")}>Quiz</Button>
         </Box>
+        <Typography variant="subtitle2" sx={{ marginTop: 2 }}>
+          "Work hard, have fun, make history."
+        </Typography>
       </Paper>
     </Box>
   );

--- a/frontend/src/QuizPage.js
+++ b/frontend/src/QuizPage.js
@@ -54,11 +54,11 @@ const QuizPage = () => {
         justifyContent: "center",
         alignItems: "center",
         minHeight: "100vh",
-        backgroundColor: "#252F3E",
+        background: "linear-gradient(135deg, #252F3E 0%, #1A202C 100%)",
         padding: "30px",
       }}
     >
-      <Paper sx={{ padding: 8, maxWidth: 600 }}>
+      <Paper className="fade-in" sx={{ padding: 8, maxWidth: 600, boxShadow: 3 }}>
         <Typography variant="h5" sx={{ textAlign: "center" }} gutterBottom>
           Quiz Page
         </Typography>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,6 +7,19 @@ body {
   color: #FFFFFF;
 }
 
+.fade-in {
+  animation: fadeIn 0.6s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;


### PR DESCRIPTION
## Summary
- rename references of **AWS Q&A** to **AWS Beacon**
- add a simple AWS logo svg
- update landing page with logo, quote, and slight animation
- add light fade-in effect for main panels and gradient backgrounds

## Testing
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*
- `npm test --silent --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684228a24064833186296c5e42b463c7